### PR TITLE
Feat: Customer Profile API

### DIFF
--- a/config/checkstyle/naver-checkstyle-rules.xml
+++ b/config/checkstyle/naver-checkstyle-rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!-- Naver coding convention for Java (version 1.2)  -->
 <!-- This rule file requires Checkstyle version 8.24 or above. -->
@@ -17,417 +17,423 @@ The following rules in the Naver coding convention cannot be checked by this con
 - [space-around-comment]
 -->
 
-<module name = "Checker">
-	<property name="severity" value="warning"/>
-	<property name="fileExtensions" value="java"/>
+<module name="Checker">
+    <property name="severity" value="warning"/>
+    <property name="fileExtensions" value="java"/>
 
-	<!-- [encoding-utf8] -->
-	<property name="charset" value="UTF-8"/>
+    <!-- [encoding-utf8] -->
+    <property name="charset" value="UTF-8"/>
 
-	<!-- [newline-lf] -->
-	<module name="RegexpMultiline">
-		<property name="format" value="\r\n"/>
-		<property name="message" value="[newline-lf] Line must end with LF, not CRLF"/>
-	</module>
-
-
-	<!-- [newline-eof] -->
-	<module name="NewlineAtEndOfFile">
-		<property name="lineSeparator" value="lf"/>
-	</module>
-
-	<!-- [no-trailing-spaces] -->
-	<module name="RegexpSingleline">
-		<property name="format" value="^(?!\s+\* $).*?\s+$"/>
-		<property name="message" value="[no-trailing-spaces] Line has trailing spaces."/>
-	</module>
-
-	<!-- [line-length-120] -->
-	<property name="tabWidth" value="4"/>
-	<module name="LineLength">
-		<property name="max" value="120"/>
-		<property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-		<message key="maxLineLen"
-				 value="[line-length-120] Line is longer than {0,number,integer} characters (found {1,number,integer})"/>
-	</module>
-
-	<module name="TreeWalker">
-		<!-- Start of Naming chapter -->
-
-		<!-- [list-uppercase-abbr] -->
-		<module name="AbbreviationAsWordInName">
-			<property name="ignoreFinal" value="false"/>
-			<property name="allowedAbbreviationLength" value="1"/>
-			<message key="abbreviation.as.word"
-					 value="[list-uppercase-abbr] Abbreviation in name ''{0}'' must contain no more than {1}"/>
-			<property name="allowedAbbreviations" value="DAO,BO"/>
-		</module>
-
-		<!-- [package-lowercase] -->
-		<module name="PackageName">
-			<property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
-			<message key="name.invalidPattern"
-					 value="[package-lowercase] Package name ''{0}'' must match pattern ''{1}''."/>
-		</module>
+    <!-- [newline-lf] -->
+    <module name="RegexpMultiline">
+        <property name="format" value="\r\n"/>
+        <property name="message" value="[newline-lf] Line must end with LF, not CRLF"/>
+    </module>
 
 
-		<!-- [class-interface-lower-camelcase] -->
-		<module name="TypeName">
-			<message key="name.invalidPattern"
-					 value="[class-interface-lower-camelcase] Type name ''{0}'' must match pattern ''{1}''."/>
-		</module>
+    <!-- [newline-eof] -->
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
 
-		<!-- [method-lower-camelcase] -->
-		<module name="MethodName">
-			<property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
-			<message key="name.invalidPattern"
-					 value="[method-lower-camelcase] Method name ''{0}'' must match pattern ''{1}''."/>
-		</module>
+    <!-- [no-trailing-spaces] -->
+    <module name="RegexpSingleline">
+        <property name="format" value="^(?!\s+\* $).*?\s+$"/>
+        <property name="message" value="[no-trailing-spaces] Line has trailing spaces."/>
+    </module>
 
-		<!-- [var-lower-camelcase] -->
-		<module name="MemberName">
-			<property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
-			<message key="name.invalidPattern"
-					 value="[var-lower-camelcase] Member name ''{0}'' must match pattern ''{1}''."/>
-		</module>
-		<module name="ParameterName">
-			<property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
-			<message key="name.invalidPattern"
-					 value="[var-lower-camelcase] Parameter name ''{0}'' must match pattern ''{1}''."/>
-		</module>
+    <!-- [line-length-120] -->
+    <property name="tabWidth" value="4"/>
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        <message key="maxLineLen"
+                 value="[line-length-120] Line is longer than {0,number,integer} characters (found {1,number,integer})"/>
+    </module>
 
-		<!-- [var-lower-camelcase], [avoid-1-char-var] -->
-		<module name="LocalVariableName">
-			<property name="tokens" value="VARIABLE_DEF"/>
-			<property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
-			<property name="allowOneCharVarInForLoop" value="true"/>
-			<message key="name.invalidPattern"
-					 value="[var-lower-camelcase][avoid-1-char-var] Local variable name ''{0}'' must match pattern ''{1}''."/>
-		</module>
+    <module name="TreeWalker">
+        <!-- Start of Naming chapter -->
 
-		<!-- End of Naming chapter -->
+        <!-- [list-uppercase-abbr] -->
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+            <message key="abbreviation.as.word"
+                     value="[list-uppercase-abbr] Abbreviation in name ''{0}'' must contain no more than {1}"/>
+            <property name="allowedAbbreviations" value="DAO,BO"/>
+        </module>
 
-		<!-- Start of Declarations chapter -->
+        <!-- [package-lowercase] -->
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+                     value="[package-lowercase] Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
 
-		<!-- [1-top-level-class] -->
-		<module name="OneTopLevelClass"/>
-		<message key="name.invalidPattern"
-				 value="[1-top-level-class] one.top.level.class=Top-level class {0} has to reside in its own source file."/>
 
-		<!-- [avoid-star-import] -->
-		<module name="AvoidStarImport">
-			<property name="allowStaticMemberImports" value="true"/>
-			<message key="import.avoidStar"
-					 value="[avoid-star-import] Using the ''.*'' form of import should be avoided - {0}."/>
-		</module>
+        <!-- [class-interface-lower-camelcase] -->
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+                     value="[class-interface-lower-camelcase] Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
 
-		<!-- [modifier-order] -->
-		<module name="ModifierOrder">
-			<message key="mod.order"
-					 value="[modifier-order] ''{0}'' modifier out of order with the JLS suggestions."/>
-			<message key="annotation.order"
-					 value="[modifier-order] ''{0}'' annotation modifier does not precede non-annotation modifiers."/>
-		</module>
+        <!-- [method-lower-camelcase] -->
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="[method-lower-camelcase] Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
 
-		<!-- [newline-after-annotation] -->
-		<module name="AnnotationLocation">
-			<property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
-			<property name="allowSamelineSingleParameterlessAnnotation" value="true"/>
-			<message key="annotation.location.alone"
-					 value="[newline-after-annotation] Annotation ''{0}'' should be alone on line."/>
-		</module>
+        <!-- [var-lower-camelcase] -->
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="[var-lower-camelcase] Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="[var-lower-camelcase] Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
 
-		<!-- [1-state-per-line] -->
-		<module name="OneStatementPerLine">
-			<message key="needBraces"
-					 value="[1-state-per-line] Only one statement per line allowed."/>
-		</module>
+        <!-- [var-lower-camelcase], [avoid-1-char-var] -->
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+                     value="[var-lower-camelcase][avoid-1-char-var] Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
 
-		<!-- [1-var-per-declaration] -->
-		<module name="MultipleVariableDeclarations">
-			<message key="multiple.variable.declarations"
-					 value="[1-var-per-declaration] Only one variable definition per line allowed."/>
-			<message key="multiple.variable.declarations.comma"
-					 value="[1-var-per-declaration] Each variable declaration must be in its own statement."/>
-		</module>
+        <!-- End of Naming chapter -->
 
-		<!-- [array-square-after-type] -->
-		<module name="ArrayTypeStyle">
-			<message key="array.type.style"
-					 value="[array-square-after-type] Array brackets at illegal position."/>
-		</module>
+        <!-- Start of Declarations chapter -->
 
-		<!-- [long-value-suffix] -->
-		<module name="UpperEll">
-			<message key="upperEll" value="[long-value-suffix] Should use uppercase ''L''."/>
-		</module>
+        <!-- [1-top-level-class] -->
+        <module name="OneTopLevelClass"/>
+        <message key="name.invalidPattern"
+                 value="[1-top-level-class] one.top.level.class=Top-level class {0} has to reside in its own source file."/>
 
-		<!-- [special-escape] -->
-		<module name="IllegalTokenText">
-			<property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
-			<property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
-			<property name="message" value="[array-square-after-type]  Avoid using corresponding octal or Unicode escape."/>
-		</module>
+        <!-- [avoid-star-import] -->
+        <module name="AvoidStarImport">
+            <property name="allowStaticMemberImports" value="true"/>
+            <message key="import.avoidStar"
+                     value="[avoid-star-import] Using the ''.*'' form of import should be avoided - {0}."/>
+        </module>
 
-		<!-- End of Declarations chapter -->
+        <!-- [modifier-order] -->
+        <module name="ModifierOrder">
+            <message key="mod.order"
+                     value="[modifier-order] ''{0}'' modifier out of order with the JLS suggestions."/>
+            <message key="annotation.order"
+                     value="[modifier-order] ''{0}'' annotation modifier does not precede non-annotation modifiers."/>
+        </module>
 
-		<!-- Start of Indentation chapter -->
+        <!-- [newline-after-annotation] -->
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+            <property name="allowSamelineSingleParameterlessAnnotation" value="true"/>
+            <message key="annotation.location.alone"
+                     value="[newline-after-annotation] Annotation ''{0}'' should be alone on line."/>
+        </module>
 
-		<!-- [4-spaces-tab] -->
-		<property name="tabWidth" value="4"/>
+        <!-- [1-state-per-line] -->
+        <module name="OneStatementPerLine">
+            <message key="needBraces"
+                     value="[1-state-per-line] Only one statement per line allowed."/>
+        </module>
 
-		<!-- [indentation-tab] -->
-		<module name="RegexpSinglelineJava">
-			<property name="format" value="^\t* "/>
-			<property name="message" value="[indentation-tab] Indent must use tab characters"/>
-			<property name="ignoreComments" value="true"/>
-		</module>
+        <!-- [1-var-per-declaration] -->
+        <module name="MultipleVariableDeclarations">
+            <message key="multiple.variable.declarations"
+                     value="[1-var-per-declaration] Only one variable definition per line allowed."/>
+            <message key="multiple.variable.declarations.comma"
+                     value="[1-var-per-declaration] Each variable declaration must be in its own statement."/>
+        </module>
 
-		<!-- End of Indentation chapter -->
+        <!-- [array-square-after-type] -->
+        <module name="ArrayTypeStyle">
+            <message key="array.type.style"
+                     value="[array-square-after-type] Array brackets at illegal position."/>
+        </module>
 
-		<!-- Start of Braces chapter -->
+        <!-- [long-value-suffix] -->
+        <module name="UpperEll">
+            <message key="upperEll" value="[long-value-suffix] Should use uppercase ''L''."/>
+        </module>
 
-		<!-- [braces-knr-style]-->
-		<module name="LeftCurly">
-			<message key="line.break.after"
-					 value="[braces-knr-style] ''{0}'' at column {1} should have line break after."/>
-			<message key="line.new"
-					 value="[braces-knr-style] ''{0}'' at column {1} should be on a new line."/>
-			<message key="line.previous"
-					 value="[braces-knr-style] ''{0}'' at column {1} should be on the previous line."/>
-		</module>
-		<module name="RightCurly">
-			<property name="option" value="alone"/>
-			<property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
-			<message key="line.alone"
-					 value="[braces-knr-style] ''{0}'' at column {1} should be alone on a line."/>
-			<message key="line.break.before"
-					 value="[braces-knr-style] =''{0}'' at column {1} should have line break before."/>
-			<message key="line.new"
-					 value="[braces-knr-style] ''{0}'' at column {1} should be on a new line."/>
-		</module>
+        <!-- [special-escape] -->
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format"
+                      value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message"
+                      value="[array-square-after-type]  Avoid using corresponding octal or Unicode escape."/>
+        </module>
 
-		<!-- [sub-flow-after-brace] -->
-		<module name="RightCurly">
-			<property name="option" value="same"/>
-			<property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
-			<message key="line.same"
-					 value="[sub-flow-after-brace] ''{0}'' at column {1} should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else or try/catch/finally)."/>
-			<message key="line.break.before"
-					 value="[sub-flow-after-brace] ''{0}'' at column {1} should have line break before."/>
-		</module>
+        <!-- End of Declarations chapter -->
 
-		<!-- [need-braces] -->
-		<module name="NeedBraces">
-			<message key="needBraces"
-					 value="[need-braces] ''{0}'' statement must use '''{}'''s."/>
-		</module>
+        <!-- Start of Indentation chapter -->
 
-		<!-- End of Braces chapter -->
+        <!-- [4-spaces-tab] -->
+        <property name="tabWidth" value="4"/>
 
-		<!-- Start of Line-wrapping chapter -->
+        <!-- [indentation-tab] -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t* "/>
+            <property name="message" value="[indentation-tab] Indent must use tab characters"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
 
-		<!-- [1-line-package-import]-->
-		<module name="NoLineWrap">
-			<property name="tokens" value="PACKAGE_DEF, IMPORT"/>
-			<message key="no.line.wrap"
-					 value="[1-line-package-import] {0} statement should not be line-wrapped."/>
-		</module>
+        <!-- End of Indentation chapter -->
 
-		<!-- [block-indentation][indentation-after-line-wrapping] -->
-		<!-- checkstyle 6.16 이상을 써야지 탭을 쓸때의 인덴트 체크가 제대로 동작함 -->
-		<module name="Indentation">
-			<property name="basicOffset" value="4"/>
-			<property name="braceAdjustment" value="0"/>
-			<property name="caseIndent" value="4"/>
-			<property name="throwsIndent" value="4"/>
-			<property name="lineWrappingIndentation" value="4"/>
-			<property name="arrayInitIndent" value="4"/>
-		</module>
+        <!-- Start of Braces chapter -->
 
-		<!-- [line-wrapping-position] -->
-		<module name="SeparatorWrap">
-			<property name="tokens" value="COMMA"/>
-			<property name="option" value="EOL"/>
-			<message key="line.previous"
-					 value="[line-wrapping-position] ''{0}'' should be on the previous line."/>
-		</module>
-		<module name="SeparatorWrap">
-			<property name="tokens" value="DOT"/>
-			<property name="option" value="NL"/>
-			<message key="line.new"
-					 value="[line-wrapping-position] ''{0}'' should be on a new line."/>
-		</module>
-		<module name="OperatorWrap">
-			<property name="option" value="NL"/>
-			<property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
-			<message key="line.new"
-					 value="[line-wrapping-position] ''{0}'' should be on a new line."/>
-		</module>
+        <!-- [braces-knr-style]-->
+        <module name="LeftCurly">
+            <message key="line.break.after"
+                     value="[braces-knr-style] ''{0}'' at column {1} should have line break after."/>
+            <message key="line.new"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be on a new line."/>
+            <message key="line.previous"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be on the previous line."/>
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens"
+                      value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+            <message key="line.alone"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be alone on a line."/>
+            <message key="line.break.before"
+                     value="[braces-knr-style] =''{0}'' at column {1} should have line break before."/>
+            <message key="line.new"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be on a new line."/>
+        </module>
 
-		<!-- End of Line-wrapping chapter -->
+        <!-- [sub-flow-after-brace] -->
+        <module name="RightCurly">
+            <property name="option" value="same"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+            <message key="line.same"
+                     value="[sub-flow-after-brace] ''{0}'' at column {1} should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else or try/catch/finally)."/>
+            <message key="line.break.before"
+                     value="[sub-flow-after-brace] ''{0}'' at column {1} should have line break before."/>
+        </module>
 
-		<!-- Start of Blank lines chapter -->
+        <!-- [need-braces] -->
+        <module name="NeedBraces">
+            <message key="needBraces"
+                     value="[need-braces] ''{0}'' statement must use '''{}'''s."/>
+        </module>
 
-		<!-- [blankline-after-package] -->
-		<!--
-		This module always requires an empty line between header and package.
-		But it is not forced in the Naver guide.
-		See https://github.com/checkstyle/checkstyle/issues/1035
-		<module name="EmptyLineSeparator">
-			<property name="tokens" value="PACKAGE_DEF"/>
-			<message key="empty.line.separator"
-				value="[blankline-after-package] ''{0}'' should be separated from previous statement."/>
-		</module>
-		-->
+        <!-- End of Braces chapter -->
 
-		<!-- [import-grouping] -->
-		<module name="ImportOrder">
-			<property name="groups" value="java., javax., org., net., /com\.(?!nhncorp|navercorp|naver)/, /(?!java\.|javax\.|com\.|org\.|net\.)/, com.nhncorp., com.navercorp., com.naver."/>
-			<property name="ordered" value="true"/>
-			<property name="separated" value="true"/>
-			<property name="option" value="top"/>
-			<property name="sortStaticImportsAlphabetically" value="true"/>
-			<message key="import.groups.separated.internally"
-					 value="[import-grouping] Extra separation in import group before ''{0}''"/>
-			<message key="import.ordering"
-					 value="[import-grouping] Wrong order for ''{0}'' import."/>
-			<message key="import.separation"
-					 value="[import-grouping] ''{0}'' should be separated from previous imports."/>
-		</module>
+        <!-- Start of Line-wrapping chapter -->
 
-		<!-- [blankline-between-methods] -->
-		<module name="EmptyLineSeparator">
-			<property name="tokens" value="METHOD_DEF"/>
-			<message key="empty.line.separator"
-					 value="[blankline-between-methods] ''{0}'' should be separated from previous statement."/>
-		</module>
+        <!-- [1-line-package-import]-->
+        <module name="NoLineWrap">
+            <property name="tokens" value="PACKAGE_DEF, IMPORT"/>
+            <message key="no.line.wrap"
+                     value="[1-line-package-import] {0} statement should not be line-wrapped."/>
+        </module>
 
-		<!-- End of Blank lines chapter -->
+        <!-- [block-indentation][indentation-after-line-wrapping] -->
+        <!-- checkstyle 6.16 이상을 써야지 탭을 쓸때의 인덴트 체크가 제대로 동작함 -->
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="4"/>
+        </module>
 
-		<!-- Start of Whitespace chapter -->
+        <!-- [line-wrapping-position] -->
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+            <message key="line.previous"
+                     value="[line-wrapping-position] ''{0}'' should be on the previous line."/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="NL"/>
+            <message key="line.new"
+                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens"
+                      value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+            <message key="line.new"
+                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>
+        </module>
 
-		<!-- [space-around-brace] -->
-		<module name="WhitespaceAround">
-			<property name="allowEmptyConstructors" value="true"/> <!-- [permit-concise-empty-block] -->
-			<property name="allowEmptyMethods" value="true"/>  <!-- [permit-concise-empty-block] -->
-			<property name="allowEmptyLoops" value="true"/>  <!-- [permit-concise-empty-block] -->
-			<property name="tokens" value="LCURLY, RCURLY, SLIST"/>
-			<message key="ws.notFollowed"
-					 value="[space-around-brace] ''{0}'' is not followed by whitespace."/>
-			<message key="ws.notPreceded"
-					 value="[space-around-brace] ''{0}'' is not preceded with whitespace."/>
-		</module>
+        <!-- End of Line-wrapping chapter -->
 
-		<!-- [space-between-keyword-parentheses] -->
-		<module name="WhitespaceAround">
-			<property name="tokens" value="
+        <!-- Start of Blank lines chapter -->
+
+        <!-- [blankline-after-package] -->
+        <!--
+        This module always requires an empty line between header and package.
+        But it is not forced in the Naver guide.
+        See https://github.com/checkstyle/checkstyle/issues/1035
+        <module name="EmptyLineSeparator">
+            <property name="tokens" value="PACKAGE_DEF"/>
+            <message key="empty.line.separator"
+                value="[blankline-after-package] ''{0}'' should be separated from previous statement."/>
+        </module>
+        -->
+
+        <!-- [import-grouping] -->
+        <module name="ImportOrder">
+            <property name="groups"
+                      value="java., javax., org., net., /com\.(?!nhncorp|navercorp|naver)/, /(?!java\.|javax\.|com\.|org\.|net\.)/, com.nhncorp., com.navercorp., com.naver."/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="top"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+            <message key="import.groups.separated.internally"
+                     value="[import-grouping] Extra separation in import group before ''{0}''"/>
+            <message key="import.ordering"
+                     value="[import-grouping] Wrong order for ''{0}'' import."/>
+            <message key="import.separation"
+                     value="[import-grouping] ''{0}'' should be separated from previous imports."/>
+        </module>
+
+        <!-- [blankline-between-methods] -->
+        <module name="EmptyLineSeparator">
+            <property name="tokens" value="METHOD_DEF"/>
+            <message key="empty.line.separator"
+                     value="[blankline-between-methods] ''{0}'' should be separated from previous statement."/>
+        </module>
+
+        <!-- End of Blank lines chapter -->
+
+        <!-- Start of Whitespace chapter -->
+
+        <!-- [space-around-brace] -->
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/> <!-- [permit-concise-empty-block] -->
+            <property name="allowEmptyMethods" value="true"/>  <!-- [permit-concise-empty-block] -->
+            <property name="allowEmptyLoops" value="true"/>  <!-- [permit-concise-empty-block] -->
+            <property name="tokens" value="LCURLY, RCURLY, SLIST"/>
+            <message key="ws.notFollowed"
+                     value="[space-around-brace] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-around-brace] ''{0}'' is not preceded with whitespace."/>
+        </module>
+
+        <!-- [space-between-keyword-parentheses] -->
+        <module name="WhitespaceAround">
+            <property name="tokens" value="
 				DO_WHILE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
 			 	LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE,"
-			/>
-			<message key="ws.notFollowed"
-					 value="[space-between-keyword-parentheses] ''{0}'' is not followed by whitespace."/>
-			<message key="ws.notPreceded"
-					 value="[space-between-keyword-parentheses] ''{0}'' is not preceded with whitespace."/>
-		</module>
+            />
+            <message key="ws.notFollowed"
+                     value="[space-between-keyword-parentheses] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-between-keyword-parentheses] ''{0}'' is not preceded with whitespace."/>
+        </module>
 
-		<!-- [no-space-between-identifier-parentheses] -->
-		<module name="MethodParamPad">
-			<message key="line.previous"
-					 value="[no-space-between-identifier-parentheses] ''{0}'' should be on the previous line."/>
-			<message key="ws.preceded"
-					 value="[no-space-between-identifier-parentheses] ''{0}'' is preceded with whitespace."/>
-		</module>
+        <!-- [no-space-between-identifier-parentheses] -->
+        <module name="MethodParamPad">
+            <message key="line.previous"
+                     value="[no-space-between-identifier-parentheses] ''{0}'' should be on the previous line."/>
+            <message key="ws.preceded"
+                     value="[no-space-between-identifier-parentheses] ''{0}'' is preceded with whitespace."/>
+        </module>
 
-		<!-- [no-space-typecasting] -->
-		<module name="TypecastParenPad">
-			<property name="tokens" value="RPAREN,TYPECAST"/>
-			<message key="ws.followed"
-					 value="[no-space-typecasting] ''{0}'' is followed by whitespace."/>
-			<message key="ws.preceded"
-					 value="[no-space-typecasting] ''{0}'' is preceded with whitespace."/>
-		</module>
+        <!-- [no-space-typecasting] -->
+        <module name="TypecastParenPad">
+            <property name="tokens" value="RPAREN,TYPECAST"/>
+            <message key="ws.followed"
+                     value="[no-space-typecasting] ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="[no-space-typecasting] ''{0}'' is preceded with whitespace."/>
+        </module>
 
-		<!-- [generic-whitespace] -->
-		<module name="GenericWhitespace">
-			<message key="ws.followed"
-					 value="[generic-whitespace] ''{0}'' is followed by whitespace."/>
-			<message key="ws.preceded"
-					 value="[generic-whitespace] ''{0}'' is preceded with whitespace."/>
-			<message key="ws.illegalFollow"
-					 value="[generic-whitespace] ''{0}'' should followed by whitespace."/>
-			<message key="ws.notPreceded"
-					 value="[generic-whitespace] ''{0}'' is not preceded with whitespace."/>
-		</module>
+        <!-- [generic-whitespace] -->
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                     value="[generic-whitespace] ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="[generic-whitespace] ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+                     value="[generic-whitespace] ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[generic-whitespace] ''{0}'' is not preceded with whitespace."/>
+        </module>
 
-		<!-- [space-after-comma-semicolon] -->
-		<module name="WhitespaceAfter">
-			<property name="tokens" value="COMMA,SEMI"/>
-			<message key="ws.notFollowed"
-					 value="[space-after-comma-semicolon]: ''{0}'' is not followed by whitespace."/>
-		</module>
-		<module name="NoWhitespaceBefore">
-			<property name="tokens" value="COMMA,SEMI"/>
-			<message key="ws.preceded"
-					 value="[space-after-comma-semicolon] ''{0}'' is preceded with whitespace."/>
-		</module>
+        <!-- [space-after-comma-semicolon] -->
+        <module name="WhitespaceAfter">
+            <property name="tokens" value="COMMA,SEMI"/>
+            <message key="ws.notFollowed"
+                     value="[space-after-comma-semicolon]: ''{0}'' is not followed by whitespace."/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="COMMA,SEMI"/>
+            <message key="ws.preceded"
+                     value="[space-after-comma-semicolon] ''{0}'' is preceded with whitespace."/>
+        </module>
 
-		<!-- [space-around-colon] -->
-		<module name="WhitespaceAround">
-			<property name="tokens" value="COLON"/>
-			<property name="ignoreEnhancedForColon" value="false"/>
-			<message key="ws.notFollowed"
-					 value="[space-around-colon] ''{0}'' is not followed by whitespace."/>
-			<message key="ws.notPreceded"
-					 value="[space-around-colon] ''{0}'' is not preceded with whitespace."/>
-		</module>
+        <!-- [space-around-colon] -->
+        <module name="WhitespaceAround">
+            <property name="tokens" value="COLON"/>
+            <property name="ignoreEnhancedForColon" value="false"/>
+            <message key="ws.notFollowed"
+                     value="[space-around-colon] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-around-colon] ''{0}'' is not preceded with whitespace."/>
+        </module>
 
-		<!-- [no-space-unary-operator] -->
-		<module name="NoWhitespaceBefore">
-			<property name="tokens" value="POST_INC, POST_DEC"/>
-			<message key="ws.preceded"
-					 value="[no-space-unary-operator] ''{0}'' is preceded with whitespace."/>
-		</module>
-		<module name="NoWhitespaceAfter">
-			<property name="tokens" value="INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT"/>
-			<message key="ws.followed"
-					 value="[no-space-unary-operator] whitespace ''{0}'' is followed by whitespace."/>
-		</module>
+        <!-- [no-space-unary-operator] -->
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="POST_INC, POST_DEC"/>
+            <message key="ws.preceded"
+                     value="[no-space-unary-operator] ''{0}'' is preceded with whitespace."/>
+        </module>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT"/>
+            <message key="ws.followed"
+                     value="[no-space-unary-operator] whitespace ''{0}'' is followed by whitespace."/>
+        </module>
 
-		<!-- [space-around-binary-ternary-operator] -->
-		<module name="WhitespaceAround">
-			<property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, DIV,
+        <!-- [space-around-binary-ternary-operator] -->
+        <module name="WhitespaceAround">
+            <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, DIV,
 				 DIV_ASSIGN, EQUAL, GE, GT, LAND, LE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL,
 				 PLUS, PLUS_ASSIGN, QUESTION, SL, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
-			<message key="ws.notFollowed"
-					 value="[space-around-binary-ternary-operator] ''{0}'' is not followed by whitespace."/>
-			<message key="ws.notPreceded"
-					 value="[space-around-binary-ternary-operator] ''{0}'' is not preceded with whitespace."/>
-		</module>
+            <message key="ws.notFollowed"
+                     value="[space-around-binary-ternary-operator] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-around-binary-ternary-operator] ''{0}'' is not preceded with whitespace."/>
+        </module>
 
-		<!-- End of Whitespace chapter -->
+        <!-- End of Whitespace chapter -->
 
-		<!--- Suppression -->
-		<module name="SuppressionCommentFilter">
-			<property name="offCommentFormat" value="@checkstyle:off"/>
-			<property name="onCommentFormat" value="@checkstyle:on"/>
-		</module>
-		<module name="SuppressWithNearbyCommentFilter">
-			<property name="commentFormat" value="@checkstyle:ignore"/>
-			<property name="checkFormat" value=".*"/>
-			<property name="influenceFormat" value="0"/>
-		</module>
-	</module>
+        <!--- Suppression -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="@checkstyle:off"/>
+            <property name="onCommentFormat" value="@checkstyle:on"/>
+        </module>
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="commentFormat" value="@checkstyle:ignore"/>
+            <property name="checkFormat" value=".*"/>
+            <property name="influenceFormat" value="0"/>
+        </module>
+    </module>
 
-	<!--- Suppression -->
-	<module name="SuppressionFilter">
-		<property name="file" value="${suppressionFile}"/>
-		<property name="optional" value="true"/>
-	</module>
+    <!--- Suppression -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${suppressionFile}"/>
+        <property name="optional" value="true"/>
+    </module>
 
-	<!--- Exclude module-info.java -->
-	<module name="BeforeExecutionExclusionFileFilter">
-		<property name="fileNamePattern" value="module\-info\.java$"/>
-	</module>
+    <!--- Exclude module-info.java -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
 
 </module>

--- a/config/checkstyle/naver-checkstyle-suppressions.xml
+++ b/config/checkstyle/naver-checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
-"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
 </suppressions>

--- a/src/main/java/personal/hdproject/HdProjectApplication.java
+++ b/src/main/java/personal/hdproject/HdProjectApplication.java
@@ -2,7 +2,9 @@ package personal.hdproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HdProjectApplication {
 

--- a/src/main/java/personal/hdproject/customer/dao/CustomerRepository.java
+++ b/src/main/java/personal/hdproject/customer/dao/CustomerRepository.java
@@ -1,0 +1,10 @@
+package personal.hdproject.customer.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import personal.hdproject.customer.dao.common.CustomeCustomRepository;
+import personal.hdproject.customer.domain.Customer;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long>, CustomeCustomRepository {
+
+}

--- a/src/main/java/personal/hdproject/customer/dao/CustomerRepository.java
+++ b/src/main/java/personal/hdproject/customer/dao/CustomerRepository.java
@@ -4,10 +4,10 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import personal.hdproject.customer.dao.common.CustomeCustomRepository;
+import personal.hdproject.customer.dao.common.CustomerCustomRepository;
 import personal.hdproject.customer.domain.Customer;
 
-public interface CustomerRepository extends JpaRepository<Customer, Long>, CustomeCustomRepository {
+public interface CustomerRepository extends JpaRepository<Customer, Long>, CustomerCustomRepository {
 
 	Optional<Customer> findCustomerByEmail(String email);
 }

--- a/src/main/java/personal/hdproject/customer/dao/CustomerRepository.java
+++ b/src/main/java/personal/hdproject/customer/dao/CustomerRepository.java
@@ -1,5 +1,7 @@
 package personal.hdproject.customer.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import personal.hdproject.customer.dao.common.CustomeCustomRepository;
@@ -7,4 +9,5 @@ import personal.hdproject.customer.domain.Customer;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long>, CustomeCustomRepository {
 
+	Optional<Customer> findCustomerByEmail(String email);
 }

--- a/src/main/java/personal/hdproject/customer/dao/common/CustomeCustomRepository.java
+++ b/src/main/java/personal/hdproject/customer/dao/common/CustomeCustomRepository.java
@@ -1,0 +1,8 @@
+package personal.hdproject.customer.dao.common;
+
+public interface CustomeCustomRepository {
+
+	Long updateNickname(Long customerId, String nickname);
+
+	Long updatePhone(Long customerId, String phone);
+}

--- a/src/main/java/personal/hdproject/customer/dao/common/CustomerCustomRepository.java
+++ b/src/main/java/personal/hdproject/customer/dao/common/CustomerCustomRepository.java
@@ -1,6 +1,6 @@
 package personal.hdproject.customer.dao.common;
 
-public interface CustomeCustomRepository {
+public interface CustomerCustomRepository {
 
 	Long updateNickname(Long customerId, String nickname);
 

--- a/src/main/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryImpl.java
+++ b/src/main/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryImpl.java
@@ -7,12 +7,12 @@ import org.springframework.transaction.annotation.Transactional;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
-import personal.hdproject.customer.dao.common.CustomeCustomRepository;
+import personal.hdproject.customer.dao.common.CustomerCustomRepository;
 import personal.hdproject.customer.domain.QCustomer;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomerRepositoryImpl implements CustomeCustomRepository {
+public class CustomerRepositoryImpl implements CustomerCustomRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 	private final QCustomer customer = QCustomer.customer;

--- a/src/main/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryImpl.java
+++ b/src/main/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryImpl.java
@@ -1,5 +1,7 @@
 package personal.hdproject.customer.dao.jpa;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +23,9 @@ public class CustomerRepositoryImpl implements CustomerCustomRepository {
 	@Modifying(clearAutomatically = true)
 	@Override
 	public Long updateNickname(Long customerId, String nickname) {
-		return jpaQueryFactory.update(customer).set(customer.nickname, nickname)
+		return jpaQueryFactory.update(customer)
+			.set(customer.nickname, nickname)
+			.set(customer.updatedAt, LocalDateTime.now())
 			.where(customer.id.eq(customerId)).execute();
 	}
 
@@ -29,7 +33,9 @@ public class CustomerRepositoryImpl implements CustomerCustomRepository {
 	@Modifying(clearAutomatically = true)
 	@Override
 	public Long updatePhone(Long customerId, String phone) {
-		return jpaQueryFactory.update(customer).set(customer.phone, phone)
+		return jpaQueryFactory.update(customer)
+			.set(customer.phone, phone)
+			.set(customer.updatedAt, LocalDateTime.now())
 			.where(customer.id.eq(customerId)).execute();
 	}
 }

--- a/src/main/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryImpl.java
+++ b/src/main/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryImpl.java
@@ -1,0 +1,35 @@
+package personal.hdproject.customer.dao.jpa;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import personal.hdproject.customer.dao.common.CustomeCustomRepository;
+import personal.hdproject.customer.domain.QCustomer;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomerRepositoryImpl implements CustomeCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+	private final QCustomer customer = QCustomer.customer;
+
+	@Transactional
+	@Modifying(clearAutomatically = true)
+	@Override
+	public Long updateNickname(Long customerId, String nickname) {
+		return jpaQueryFactory.update(customer).set(customer.nickname, nickname)
+			.where(customer.id.eq(customerId)).execute();
+	}
+
+	@Transactional
+	@Modifying(clearAutomatically = true)
+	@Override
+	public Long updatePhone(Long customerId, String phone) {
+		return jpaQueryFactory.update(customer).set(customer.phone, phone)
+			.where(customer.id.eq(customerId)).execute();
+	}
+}

--- a/src/main/java/personal/hdproject/customer/domain/Customer.java
+++ b/src/main/java/personal/hdproject/customer/domain/Customer.java
@@ -13,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import personal.hdproject.customer.service.request.CreateCustomerServiceRequest;
 import personal.hdproject.util.wrapper.BaseEntity;
 
 @Getter
@@ -51,5 +52,15 @@ public class Customer extends BaseEntity {
 		this.nickname = nickname;
 		this.phone = phone;
 		this.grade = grade;
+	}
+
+	public static Customer toEntity(CreateCustomerServiceRequest request, String encryptedPassword) {
+		return Customer.builder()
+			.email(request.getEmail())
+			.password(encryptedPassword)
+			.nickname(request.getNickname())
+			.phone(request.getPhone())
+			.grade(Grade.BASIC)
+			.build();
 	}
 }

--- a/src/main/java/personal/hdproject/customer/domain/Customer.java
+++ b/src/main/java/personal/hdproject/customer/domain/Customer.java
@@ -9,6 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,17 +18,18 @@ import personal.hdproject.util.wrapper.BaseEntity;
 @Getter
 @Entity
 @Table(name = "customer")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Customer extends BaseEntity {
 
-	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "customer_id", columnDefinition = "bigint") // unsigned
 	private Long id;
 
 	@Column(columnDefinition = "varchar(255)", unique = true)
 	private String email;
 
-	@Column(columnDefinition = "char(60)")
+	@Column(columnDefinition = "char(64)")
 	private String password;
 
 	@Column(columnDefinition = "varchar(40)")

--- a/src/main/java/personal/hdproject/customer/domain/Customer.java
+++ b/src/main/java/personal/hdproject/customer/domain/Customer.java
@@ -1,0 +1,53 @@
+package personal.hdproject.customer.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import personal.hdproject.util.wrapper.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "customer")
+@NoArgsConstructor
+public class Customer extends BaseEntity {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "customer_id", columnDefinition = "bigint") // unsigned
+	private Long id;
+
+	@Column(columnDefinition = "varchar(255)", unique = true)
+	private String email;
+
+	@Column(columnDefinition = "char(60)")
+	private String password;
+
+	@Column(columnDefinition = "varchar(40)")
+	private String nickname;
+
+	@Column(columnDefinition = "varchar(40)", unique = true)
+	private String phone;
+
+	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "varchar(40)")
+	private Grade grade;
+
+	// TODO: 주문 테이블 - 연관관계 Mapping
+
+	@Builder
+	private Customer(String email, String password, String nickname, String phone, Grade grade) {
+		this.email = email;
+		this.password = password;
+		this.nickname = nickname;
+		this.phone = phone;
+		this.grade = grade;
+	}
+}

--- a/src/main/java/personal/hdproject/customer/domain/Grade.java
+++ b/src/main/java/personal/hdproject/customer/domain/Grade.java
@@ -1,0 +1,5 @@
+package personal.hdproject.customer.domain;
+
+public enum Grade {
+	BASIC, VIP
+}

--- a/src/main/java/personal/hdproject/customer/service/CustomerProfileService.java
+++ b/src/main/java/personal/hdproject/customer/service/CustomerProfileService.java
@@ -1,0 +1,52 @@
+package personal.hdproject.customer.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import personal.hdproject.customer.dao.CustomerRepository;
+import personal.hdproject.customer.domain.Customer;
+import personal.hdproject.customer.service.request.CreateCustomerServiceRequest;
+import personal.hdproject.util.encryption.Sha256Util;
+import personal.hdproject.util.error.exception.DuplicateEmailException;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerProfileService {
+
+	private final CustomerRepository customerRepository;
+
+	public Long join(CreateCustomerServiceRequest request) {
+		if (isEmailAlreadyRegistered(request.getEmail())) {
+			throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
+		}
+
+		String encryptedPassword = getEncryptedPassword(request.getPassword());
+		Customer savedCustomer = customerRepository.save(Customer.toEntity(request, encryptedPassword));
+
+		return savedCustomer.getId();
+	}
+
+	public Long changeNickname(Long customerId, String nickname) {
+		return customerRepository.updateNickname(customerId, nickname);
+	}
+
+	public Long changePhone(Long customerId, String phone) {
+		return customerRepository.updatePhone(customerId, phone);
+	}
+
+	public void deleteAccount(Long customerId) {
+		customerRepository.deleteById(customerId);
+	}
+
+	private String getEncryptedPassword(String password) {
+		return Sha256Util.getEncrypt(password);
+	}
+
+	private boolean isEmailAlreadyRegistered(String email) {
+		Optional<Customer> findCustomerOptional = customerRepository.findCustomerByEmail(email);
+
+		return findCustomerOptional.isPresent();
+	}
+}

--- a/src/main/java/personal/hdproject/customer/service/request/CreateCustomerServiceRequest.java
+++ b/src/main/java/personal/hdproject/customer/service/request/CreateCustomerServiceRequest.java
@@ -1,0 +1,21 @@
+package personal.hdproject.customer.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreateCustomerServiceRequest {
+
+	private final String email;
+	private final String password;
+	private final String nickname;
+	private final String phone;
+
+	@Builder
+	private CreateCustomerServiceRequest(String email, String password, String nickname, String phone) {
+		this.email = email;
+		this.password = password;
+		this.nickname = nickname;
+		this.phone = phone;
+	}
+}

--- a/src/main/java/personal/hdproject/customer/web/CustomerProfileController.java
+++ b/src/main/java/personal/hdproject/customer/web/CustomerProfileController.java
@@ -1,0 +1,51 @@
+package personal.hdproject.customer.web;
+
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import personal.hdproject.customer.service.CustomerProfileService;
+import personal.hdproject.customer.web.request.ChangeNicknameRequest;
+import personal.hdproject.customer.web.request.ChangePhoneRequest;
+import personal.hdproject.customer.web.request.CreateCustomerRequest;
+import personal.hdproject.util.wrapper.ApiResult;
+
+@RestController
+@RequiredArgsConstructor
+public class CustomerProfileController {
+
+	private final CustomerProfileService customerProfileService;
+
+	@PostMapping("/api/v1/customer")
+	public ApiResult<Long> joinCustomer(@Valid @RequestBody CreateCustomerRequest request) {
+		Long joinCustomerId = customerProfileService.join(request.toServiceRequest());
+
+		return ApiResult.onSuccess(joinCustomerId);
+	}
+
+	@PostMapping("/api/v1/customer-nickname/{id}")
+	public ApiResult<Long> changeCustomerNickname(@Valid @RequestBody ChangeNicknameRequest request, @PathVariable Long id) {
+		Long changedCustomerId = customerProfileService.changeNickname(id, request.getNickname());
+
+		return ApiResult.onSuccess(changedCustomerId);
+	}
+
+	@PostMapping("/api/v1/customer-phone/{id}")
+	public ApiResult<Long> changeCustomerPhone(@Valid @RequestBody ChangePhoneRequest request, @PathVariable Long id) {
+		Long changedCustomerId = customerProfileService.changePhone(id, request.getPhone());
+
+		return ApiResult.onSuccess(changedCustomerId);
+	}
+
+	@DeleteMapping("/api/v1/customer/{id}")
+	public ApiResult<String> deleteCustomerAccount(@PathVariable Long id) {
+		customerProfileService.deleteAccount(id);
+
+		return ApiResult.onSuccess("계정이 삭제되었습니다.");
+	}
+}

--- a/src/main/java/personal/hdproject/customer/web/request/ChangeNicknameRequest.java
+++ b/src/main/java/personal/hdproject/customer/web/request/ChangeNicknameRequest.java
@@ -1,0 +1,17 @@
+package personal.hdproject.customer.web.request;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChangeNicknameRequest {
+
+	@NotBlank(message = "닉네임은 공백을 허용하지 않습니다.")
+	private String nickname;
+}

--- a/src/main/java/personal/hdproject/customer/web/request/ChangePhoneRequest.java
+++ b/src/main/java/personal/hdproject/customer/web/request/ChangePhoneRequest.java
@@ -1,0 +1,19 @@
+package personal.hdproject.customer.web.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChangePhoneRequest {
+
+	@NotBlank(message = "전화번호는 필수 값입니다.")
+	@Pattern(regexp = "[0-9]{10,11}", message = "10 ~ 11자리의 숫자만 입력 가능합니다.")
+	private String phone;
+}

--- a/src/main/java/personal/hdproject/customer/web/request/CreateCustomerRequest.java
+++ b/src/main/java/personal/hdproject/customer/web/request/CreateCustomerRequest.java
@@ -1,0 +1,47 @@
+package personal.hdproject.customer.web.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+
+import lombok.Builder;
+import lombok.Getter;
+import personal.hdproject.customer.service.request.CreateCustomerServiceRequest;
+
+@Getter
+public class CreateCustomerRequest {
+
+	@Email(message = "이메일 형식으로 작성해주세요.(ex. xxxx@xxxx.com")
+	@NotBlank(message = "이메일은 필수 값입니다.")
+	private final String email;
+
+	@NotBlank(message = "비밀번호는 필수 값입나다.")
+	@Length(min = 8, message = "비밀번호는 최소 8자 이상 작성해주세요")
+	private final String password;
+
+	@NotBlank(message = "닉네임은 공백을 허용하지 않습니다.")
+	private final String nickname;
+
+	@NotBlank(message = "전화번호는 필수 값입니다.")
+	@Pattern(regexp = "[0-9]{10,11}", message = "10 ~ 11자리의 숫자만 입력 가능합니다.")
+	private final String phone;
+
+	@Builder
+	private CreateCustomerRequest(String email, String password, String nickname, String phone) {
+		this.email = email;
+		this.password = password;
+		this.nickname = nickname;
+		this.phone = phone;
+	}
+
+	public CreateCustomerServiceRequest toServiceRequest() {
+		return CreateCustomerServiceRequest.builder()
+			.email(this.email)
+			.password(this.password)
+			.nickname(this.nickname)
+			.phone(this.phone)
+			.build();
+	}
+}

--- a/src/main/java/personal/hdproject/util/encryption/Sha256Util.java
+++ b/src/main/java/personal/hdproject/util/encryption/Sha256Util.java
@@ -1,0 +1,45 @@
+package personal.hdproject.util.encryption;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class Sha256Util {
+	private static final String ENCRYPTION_TYPE = "SHA-256";
+
+	public static String getEncrypt(String source) {
+		String salt = generateSalt();
+
+		return getEncrypt(source, salt.getBytes());
+	}
+
+	private static String getEncrypt(String source, byte[] salt) {
+		try {
+			byte[] bytes = new byte[source.getBytes().length + salt.length];
+			MessageDigest md = MessageDigest.getInstance(ENCRYPTION_TYPE);
+			byte[] byteData = md.digest(bytes);
+
+			return IntStream.range(0, byteData.length)
+				.mapToObj(i -> String.format("%02x", byteData[i]))
+				.collect(Collectors.joining());
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("SHA-256 암호화 에러");
+		}
+	}
+
+	private static String generateSalt() {
+		ThreadLocalRandom random = ThreadLocalRandom.current();
+
+		byte[] salt = new byte[8];
+		random.nextBytes(salt);
+
+		StringBuilder sb = new StringBuilder();
+		for (byte b : salt) {
+			sb.append(String.format("%02x", b));
+		}
+
+		return sb.toString();
+	}
+}

--- a/src/main/java/personal/hdproject/util/error/ErrorController.java
+++ b/src/main/java/personal/hdproject/util/error/ErrorController.java
@@ -1,6 +1,7 @@
 package personal.hdproject.util.error;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,6 +16,12 @@ public class ErrorController {
 	@ExceptionHandler(DuplicateEmailException.class)
 	public ApiResult<Void> handlerDuplicateEmailRequest(DuplicateEmailException exception) {
 		return ApiResult.onFailure(exception.getLocalizedMessage());
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ApiResult<Void> handlerValidationRequest(MethodArgumentNotValidException e) {
+		return ApiResult.onFailure(e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/personal/hdproject/util/error/ErrorController.java
+++ b/src/main/java/personal/hdproject/util/error/ErrorController.java
@@ -5,10 +5,17 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import personal.hdproject.util.error.exception.DuplicateEmailException;
 import personal.hdproject.util.wrapper.ApiResult;
 
 @RestControllerAdvice
 public class ErrorController {
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(DuplicateEmailException.class)
+	public ApiResult<Void> handlerDuplicateEmailRequest(DuplicateEmailException exception) {
+		return ApiResult.onFailure(exception.getLocalizedMessage());
+	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(RuntimeException.class)

--- a/src/main/java/personal/hdproject/util/error/exception/DuplicateEmailException.java
+++ b/src/main/java/personal/hdproject/util/error/exception/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package personal.hdproject.util.error.exception;
+
+public class DuplicateEmailException extends RuntimeException {
+	public DuplicateEmailException(String message) {
+		super(message);
+	}
+}

--- a/src/test/java/personal/hdproject/BaseTestConfig.java
+++ b/src/test/java/personal/hdproject/BaseTestConfig.java
@@ -1,0 +1,20 @@
+package personal.hdproject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest
+@MockBean(JpaMetamodelMappingContext.class)
+public class BaseTestConfig {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+}

--- a/src/test/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryTest.java
+++ b/src/test/java/personal/hdproject/customer/dao/jpa/CustomerRepositoryTest.java
@@ -1,0 +1,83 @@
+package personal.hdproject.customer.dao.jpa;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import personal.hdproject.customer.dao.CustomerRepository;
+import personal.hdproject.customer.domain.Customer;
+import personal.hdproject.customer.domain.Grade;
+
+@SpringBootTest
+class CustomerRepositoryTest {
+
+	@Autowired
+	private CustomerRepository customerRepository;
+
+	@Test
+	@DisplayName(value = "소비자의 닉네임을 수정합니다.")
+	void updateNickname() {
+		// given
+		String nickname = "nickname1";
+
+		Customer customer = createCustomer("1235@gmail.com", "12345678", nickname, "00011112222");
+		Customer savedCustomer = customerRepository.save(customer);
+
+		assertThat(savedCustomer.getNickname()).isEqualTo(nickname);
+
+		// when
+		Long customerId = savedCustomer.getId();
+
+		String fixedNickname = "fixNickname";
+		customerRepository.updateNickname(customerId, fixedNickname);
+
+		// then
+		Optional<Customer> findCustomerOptional = customerRepository.findById(customerId);
+
+		findCustomerOptional.ifPresentOrElse(
+			findCustomer -> assertThat(findCustomer.getNickname()).isEqualTo(fixedNickname),
+			() -> fail("Customer should be present")
+		);
+	}
+
+	@Test
+	@DisplayName(value = "소비자의 전화번호를 수정합니다.")
+	void updatePhone() {
+		// given
+		String phone = "00011112222";
+
+		Customer customer = createCustomer("1234@gmail.com", "1234", "nickname", phone);
+		Customer savedCustomer = customerRepository.save(customer);
+
+		assertThat(savedCustomer.getPhone()).isEqualTo(phone);
+
+		// when
+		Long customerId = savedCustomer.getId();
+
+		String fixPhone = "22233334444";
+		customerRepository.updatePhone(customerId, fixPhone);
+
+		// then
+		Optional<Customer> findCustomerOptional = customerRepository.findById(customerId);
+
+		findCustomerOptional.ifPresentOrElse(
+			findCustomer -> assertThat(findCustomer.getPhone()).isEqualTo(fixPhone),
+			() -> fail("Customer should be present")
+		);
+	}
+
+	private Customer createCustomer(String mail, String password, String nickname1, String phone) {
+		return Customer.builder()
+			.email(mail)
+			.password(password)
+			.nickname(nickname1)
+			.phone(phone)
+			.grade(Grade.BASIC)
+			.build();
+	}
+}

--- a/src/test/java/personal/hdproject/customer/service/CustomerProfileServiceTest.java
+++ b/src/test/java/personal/hdproject/customer/service/CustomerProfileServiceTest.java
@@ -1,0 +1,198 @@
+package personal.hdproject.customer.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import personal.hdproject.customer.dao.CustomerRepository;
+import personal.hdproject.customer.domain.Customer;
+import personal.hdproject.customer.service.request.CreateCustomerServiceRequest;
+import personal.hdproject.util.encryption.Sha256Util;
+import personal.hdproject.util.error.exception.DuplicateEmailException;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+class CustomerProfileServiceTest {
+
+	@Autowired
+	private CustomerProfileService customerProfileService;
+
+	@Autowired
+	private CustomerRepository customerRepository;
+
+	@AfterEach
+	public void after() {
+		customerRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName(value = "이메일이 이미 존재하는지 검사하고, 비밀번호를 SHA-256으로 암호화하여 새로운 계정을 추가합니다.")
+	void join() {
+		// given
+		String email = "1234@gmail.com";
+		String password = "12345678";
+		String nickname = "nickname";
+		String phone = "00011112222";
+
+		CreateCustomerServiceRequest createCustomerDTO = getCreateCustomerServiceRequest(email, password, nickname,
+			phone);
+
+		// when
+		Long joinedCustomerId = customerProfileService.join(createCustomerDTO);
+
+		// then
+		Optional<Customer> findCustomerOptional = customerRepository.findById(joinedCustomerId);
+
+		findCustomerOptional.ifPresentOrElse(
+			findCustomer -> assertThat(findCustomer)
+				.extracting("email", "nickname", "phone")
+				.contains(email, nickname, phone),
+			() -> fail("Customer should be present")
+		);
+	}
+
+	@Test
+	@DisplayName(value = "비밀번호는 암호화되어 저장합니다. - 기존의 비밀번호와 암호화된 비밀번호는 다릅니다.")
+	void join_encryptedPassword() {
+		// given
+		String email = "1234@gmail.com";
+		String password = "12345678";
+		String nickname = "nickname";
+		String phone = "00011112222";
+
+		CreateCustomerServiceRequest createCustomerDTO = getCreateCustomerServiceRequest(email, password, nickname,
+			phone);
+
+		// when
+		Long joinedCustomerId = customerProfileService.join(createCustomerDTO);
+
+		// then
+		String encryptedPassword = Sha256Util.getEncrypt(password);
+
+		Optional<Customer> findCustomerOptional = customerRepository.findById(joinedCustomerId);
+
+		assertThat(password).isNotEqualTo(encryptedPassword);
+
+		findCustomerOptional.ifPresentOrElse(
+			findCustomer -> assertThat(findCustomer.getPassword()).isEqualTo(encryptedPassword),
+			() -> fail("Customer should be present")
+		);
+	}
+
+	@Test
+	@DisplayName(value = "이메일이 중복되어 예외가 발생합니다.")
+	void join_duplicateEmail() {
+		// given
+		String email = "1234@gmail.com";
+		String password = "12345678";
+		String nickname = "nickname";
+		String phone = "00011112222";
+
+		CreateCustomerServiceRequest createCustomerDTO = getCreateCustomerServiceRequest(email, password, nickname,
+			phone);
+
+		Long joinCustomerId = customerProfileService.join(createCustomerDTO);
+
+		Optional<Customer> findCustomerOptional = customerRepository.findById(joinCustomerId);
+		findCustomerOptional.ifPresentOrElse(
+			findCustomer -> assertThat(findCustomer.getEmail()).isEqualTo(email),
+			() -> fail("Customer should be present")
+		);
+
+		// when // then
+		assertThatThrownBy(() -> customerProfileService.join(createCustomerDTO))
+			.isInstanceOf(DuplicateEmailException.class);
+	}
+
+	@Test
+	@DisplayName(value = "닉네임을 수정합니다.")
+	void changeNickname() {
+		// given
+		String email = "1234@gmail.com";
+		String password = "12345678";
+		String nickname = "nickname";
+		String phone = "00011112222";
+
+		CreateCustomerServiceRequest createCustomerDTO = getCreateCustomerServiceRequest(email, password, nickname,
+			phone);
+
+		Long joinCustomerId = customerProfileService.join(createCustomerDTO);
+
+		// when
+		String changedNickname = "changed_nickname";
+		customerProfileService.changeNickname(joinCustomerId, changedNickname);
+
+		// then
+		Optional<Customer> findCustomerOptional = customerRepository.findById(joinCustomerId);
+
+		findCustomerOptional.ifPresentOrElse(
+			findCustomer -> assertThat(findCustomer.getNickname()).isEqualTo(changedNickname),
+			() -> fail("Customer should be present")
+		);
+	}
+
+	@Test
+	@DisplayName(value = "전화번호를 수정합니다.")
+	void changePhone() {
+		// given
+		String email = "1234@gmail.com";
+		String password = "12345678";
+		String nickname = "nickname";
+		String phone = "00011112222";
+
+		CreateCustomerServiceRequest createCustomerDTO = getCreateCustomerServiceRequest(email, password, nickname,
+			phone);
+
+		Long joinCustomerId = customerProfileService.join(createCustomerDTO);
+
+		// when
+		String changedPhone = "99988887777";
+		customerProfileService.changePhone(joinCustomerId, changedPhone);
+
+		// then
+		Optional<Customer> findCustomerOptional = customerRepository.findById(joinCustomerId);
+
+		findCustomerOptional.ifPresentOrElse(
+			findCustomer -> assertThat(findCustomer.getPhone()).isEqualTo(changedPhone),
+			() -> fail("Customer should be present")
+		);
+	}
+
+	@Test
+	@DisplayName(value = "소비자 아이디를 삭제합니다.")
+	void deleteAccount() {
+		// given
+		String email = "1234@gmail.com";
+		String password = "12345678";
+		String nickname = "nickname";
+		String phone = "00011112222";
+
+		CreateCustomerServiceRequest createCustomerDTO = getCreateCustomerServiceRequest(email, password, nickname,
+			phone);
+
+		Long joinCustomerId = customerProfileService.join(createCustomerDTO);
+
+		// when
+		customerProfileService.deleteAccount(joinCustomerId);
+
+		// then
+		Optional<Customer> findCustomerOptional = customerRepository.findById(joinCustomerId);
+
+		assertThat(findCustomerOptional.isPresent()).isFalse();
+	}
+
+	private CreateCustomerServiceRequest getCreateCustomerServiceRequest(String email, String password, String nickname,
+		String phone) {
+		return CreateCustomerServiceRequest.builder()
+			.email(email)
+			.password(password)
+			.nickname(nickname)
+			.phone(phone)
+			.build();
+	}
+}

--- a/src/test/java/personal/hdproject/customer/web/CustomerProfileControllerTest.java
+++ b/src/test/java/personal/hdproject/customer/web/CustomerProfileControllerTest.java
@@ -1,0 +1,343 @@
+package personal.hdproject.customer.web;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import personal.hdproject.BaseTestConfig;
+import personal.hdproject.customer.service.CustomerProfileService;
+import personal.hdproject.customer.web.request.ChangeNicknameRequest;
+import personal.hdproject.customer.web.request.ChangePhoneRequest;
+import personal.hdproject.customer.web.request.CreateCustomerRequest;
+
+@WebMvcTest(controllers = CustomerProfileController.class)
+class CustomerProfileControllerTest extends BaseTestConfig {
+
+	@MockBean
+	private CustomerProfileService customerProfileService;
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다.")
+	void createCustomer() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("12345678")
+			.nickname("nickname")
+			.phone("00011112222")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 이메일 형식이 다르면 예외를 반환합니다.")
+	void createCustomer_unsupportedEmailFormat() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234")
+			.password("12345678")
+			.nickname("nickname")
+			.phone("00011112222")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("이메일 형식으로 작성해주세요.(ex. xxxx@xxxx.com"));
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 이메일이 없으면 예외를 반환합니다.")
+	void createCustomer_withoutEmail() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("")
+			.password("12345678")
+			.nickname("nickname")
+			.phone("00011112222")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 비밀번호가 8자 미만이면 예외를 반환홥니다.")
+	void createCustomer_minPasswordLength() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("1234567")
+			.nickname("nickname")
+			.phone("00011112222")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("비밀번호는 최소 8자 이상 작성해주세요"));
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 비밀번호가 없으면 예외를 반환합니다.")
+	void createCustomer_withoutPassword() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("")
+			.nickname("nickname")
+			.phone("00011112222")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 닉네임이 공백이면 예외를 반환합니다.")
+	void createCustomer_notBlankNickname() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("12345678")
+			.nickname("")
+			.phone("00011112222")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+				post("/api/v1/customer")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("닉네임은 공백을 허용하지 않습니다."));
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 전화번호가 없으면 예외를 반환합니다.")
+	void createCustomer_withoutPhone() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("12345678")
+			.nickname("nickname")
+			.phone("")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 문자가 10 ~ 11자리 미만이면 예외를 반환합니다.")
+	void createCustomer_unsupportedPhoneFormat_min() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("12345678")
+			.nickname("nickname")
+			.phone("123456789")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("10 ~ 11자리의 숫자만 입력 가능합니다."));
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 문자가 10 ~ 11자리 초과면 예외를 반환합니다.")
+	void createCustomer_unsupportedPhoneFormat_max() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("12345678")
+			.nickname("nickname")
+			.phone("123456789012")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("10 ~ 11자리의 숫자만 입력 가능합니다."));
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 새로운 계정을 생성합니다. - 전화번호가 문자면 예외를 반환합니다.")
+	void createCustomer_unsupportedPhoneFormat_notNumber() throws Exception {
+		// given
+		CreateCustomerRequest request = CreateCustomerRequest.builder()
+			.email("1234@gmail.com")
+			.password("12345678")
+			.nickname("nickname")
+			.phone("123456789a")
+			.build();
+
+		// when  // then
+		mockMvc.perform(
+			post("/api/v1/customer")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("10 ~ 11자리의 숫자만 입력 가능합니다."));
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 닉네임을 수정합니다.")
+	void changeNickname() throws Exception {
+		// given
+		Long customerId = 1L;
+		ChangeNicknameRequest request = new ChangeNicknameRequest("nickname");
+
+		when(customerProfileService.changeNickname(customerId, "change_nickname")).thenReturn(customerId);
+
+		// when  // then
+		mockMvc.perform(
+				post("/api/v1/customer-nickname/" + customerId)
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 닉네임을 수정합니다. - 닉네임은 공백을 허용하지 않습니다.")
+	void changeNickname_unsupportedBlank() throws Exception {
+		// given
+		Long customerId = 1L;
+		ChangeNicknameRequest request = new ChangeNicknameRequest("");
+
+		// when  // then
+		mockMvc.perform(
+				post("/api/v1/customer-nickname/" + customerId)
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("닉네임은 공백을 허용하지 않습니다."));
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 전화번호를 수정합니다.")
+	void changePhone() throws Exception {
+		// given
+		Long customerId = 1L;
+		ChangePhoneRequest request = new ChangePhoneRequest("00011112222");
+
+		when(customerProfileService.changePhone(customerId, "00011112222")).thenReturn(customerId);
+
+		// when  // then
+		mockMvc.perform(
+				post("/api/v1/customer-phone/" + customerId)
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 전화번호를 수정합니다. - 10 ~ 11자리의 숫자만 입력 가능합니다.")
+	void changePhone_unsupportedFormat() throws Exception {
+		// given
+		Long customerId = 1L;
+		ChangePhoneRequest request = new ChangePhoneRequest("");
+
+		// when  // then
+		mockMvc.perform(
+				post("/api/v1/customer-phone/" + customerId)
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName(value = "API를 호출하여 계정을 삭제합니다.")
+	void deleteAccount() throws Exception {
+		// given
+		Long customerId = 1L;
+
+		// when  // then
+		mockMvc.perform(
+			delete("/api/v1/customer/" + customerId)
+		)
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+}


### PR DESCRIPTION
## 📅 09.06

### 🌱 Add

- Customer 엔티티
- Customer Respository Layer
- Customer Service Layer
  - 회원 가입 (비밀번호 SHA-256 암호화)
  - 닉네임 / 전화번호 수정
  - 계정 삭제
- Customer Profile Controller

- Test Code

---

> 🟤 queryDSL로 Custom Repository Interface를 추가한 이유
>
> JPA는 update를 특별하게 처리하는 기능이 없고 엔티티 클래스를 수정하면 자동으로 수정된다. 간편하지만 어떤 수정 API가 있는지 코드 레벨에서 명확하게 파악하기 어렵기 때문에 인터페이스로 Customer 에 관련된 수정 쿼리를 명시적으로 보기 위해 QueryDSL를 사용한 Custom Repository를 추가하였다.
