### PR TITLE
Refactor : Member Entity And Service, Sha-256 Util Class

### DIFF
--- a/src/main/java/personal/hdproject/member/service/MemberLoginService.java
+++ b/src/main/java/personal/hdproject/member/service/MemberLoginService.java
@@ -22,7 +22,7 @@ public class MemberLoginService {
 	private final JwtAuthTokenProvider jwtAuthTokenProvider;
 
 	public SignInMemberResponse login(SignInMemberServiceRequest request) {
-		Member member = checkAccountAndGetMember(request.getEmail(), request.getEncryptedPassword());
+		Member member = checkAccountAndGetMember(request.getEmail(), request.getPassword());
 		JwtTokenResponse jwtToken = jwtAuthTokenProvider.generateToken(member.getId());
 
 		return SignInMemberResponse.toResponse(member, jwtToken);
@@ -36,23 +36,17 @@ public class MemberLoginService {
 		return jwtAuthTokenProvider.generateRenewToken(request.getId(), request.getRefreshToken());
 	}
 
-	private Member checkAccountAndGetMember(String email, String encryptedPassword) {
-		Optional<Member> findMemberByEmailOptional = memberRepository.findMemberByEmail(email);
-
-		Member member = checkEmailAndGetMember(findMemberByEmailOptional);
-		checkPassword(member, encryptedPassword);
+	private Member checkAccountAndGetMember(String email, String password) {
+		Member member = checkEmailAndGetMember(email);
+		member.checkPassword(member, password);
 
 		return member;
 	}
 
-	private Member checkEmailAndGetMember(Optional<Member> findMemberByEmailOptional) {
+	private Member checkEmailAndGetMember(String email) {
+		Optional<Member> findMemberByEmailOptional = memberRepository.findMemberByEmail(email);
+
 		return findMemberByEmailOptional
 			.orElseThrow(() -> new LoginException("아이디가 존재하지 않습니다."));
-	}
-
-	private void checkPassword(Member member, String encryptedPassword) {
-		if (!member.getPassword().equals(encryptedPassword)) {
-			throw new LoginException("비밀번호가 일치하지 않습니다.");
-		}
 	}
 }

--- a/src/main/java/personal/hdproject/member/service/MemberProfileService.java
+++ b/src/main/java/personal/hdproject/member/service/MemberProfileService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import personal.hdproject.member.dao.MemberRepository;
 import personal.hdproject.member.domain.Member;
 import personal.hdproject.member.service.request.CreateMemberServiceRequest;
-import personal.hdproject.util.encryption.Sha256Util;
 import personal.hdproject.util.error.exception.DuplicateEmailException;
 
 @Service
@@ -22,8 +21,7 @@ public class MemberProfileService {
 			throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
 		}
 
-		String encryptedPassword = getEncryptedPassword(request.getPassword());
-		Member savedMember = memberRepository.save(Member.toEntity(request, encryptedPassword));
+		Member savedMember = memberRepository.save(Member.toEntity(request));
 
 		return savedMember.getId();
 	}
@@ -38,10 +36,6 @@ public class MemberProfileService {
 
 	public void deleteAccount(Long memberId) {
 		memberRepository.deleteById(memberId);
-	}
-
-	private String getEncryptedPassword(String password) {
-		return Sha256Util.getEncrypt(password);
 	}
 
 	private boolean isEmailAlreadyRegistered(String email) {

--- a/src/main/java/personal/hdproject/member/service/request/SignInMemberServiceRequest.java
+++ b/src/main/java/personal/hdproject/member/service/request/SignInMemberServiceRequest.java
@@ -7,11 +7,11 @@ import lombok.Getter;
 public class SignInMemberServiceRequest {
 
 	private final String email;
-	private final String encryptedPassword;
+	private final String password;
 
 	@Builder
-	private SignInMemberServiceRequest(String email, String encryptedPassword) {
+	private SignInMemberServiceRequest(String email, String password) {
 		this.email = email;
-		this.encryptedPassword = encryptedPassword;
+		this.password = password;
 	}
 }

--- a/src/main/java/personal/hdproject/member/web/MemberLoginController.java
+++ b/src/main/java/personal/hdproject/member/web/MemberLoginController.java
@@ -25,14 +25,14 @@ public class MemberLoginController {
 
 	private final MemberLoginService memberLoginService;
 
-	@PostMapping("/api/v1/member/sign-in")
+	@PostMapping("/api/v1/auth/sign-in")
 	public ApiResult<SignInMemberResponse> signInMember(@Valid @RequestBody SignInMemberRequest request) {
 		SignInMemberResponse response = memberLoginService.login(request.toServiceRequest());
 
 		return ApiResult.onSuccess(response);
 	}
 
-	@PostMapping("/api/v1/member/sign-out")
+	@PostMapping("/api/v1/auth/sign-out")
 	public ApiResult<String> signOutMember(HttpServletRequest request) {
 		String accessToken = request.getHeader(header);
 
@@ -41,7 +41,7 @@ public class MemberLoginController {
 		return ApiResult.onSuccess("로그아웃 되었습니다.");
 	}
 
-	@PostMapping("/api/v1/member/refresh-token")
+	@PostMapping("/api/v1/auth/refresh-token")
 	public ApiResult<JwtTokenResponse> getJwtToken(@Valid @RequestBody RefreshTokenRequest request) {
 		JwtTokenResponse response = memberLoginService.validateAndRenewToken(request);
 

--- a/src/main/java/personal/hdproject/member/web/request/SignInMemberRequest.java
+++ b/src/main/java/personal/hdproject/member/web/request/SignInMemberRequest.java
@@ -5,7 +5,6 @@ import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import personal.hdproject.member.service.request.SignInMemberServiceRequest;
-import personal.hdproject.util.encryption.Sha256Util;
 
 @Getter
 public class SignInMemberRequest {
@@ -23,11 +22,9 @@ public class SignInMemberRequest {
 	}
 
 	public SignInMemberServiceRequest toServiceRequest() {
-		String encryptedPassword = Sha256Util.getEncrypt(this.password);
-
 		return SignInMemberServiceRequest.builder()
 			.email(this.email)
-			.encryptedPassword(encryptedPassword)
+			.password(this.password)
 			.build();
 	}
 }

--- a/src/main/java/personal/hdproject/util/encryption/EncryptedSourceDto.java
+++ b/src/main/java/personal/hdproject/util/encryption/EncryptedSourceDto.java
@@ -1,0 +1,24 @@
+package personal.hdproject.util.encryption;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EncryptedSourceDto {
+
+	private final String encryptedSource;
+	private final String salt;
+
+	@Builder
+	private EncryptedSourceDto(String encryptedSource, String salt) {
+		this.encryptedSource = encryptedSource;
+		this.salt = salt;
+	}
+
+	public static EncryptedSourceDto toEncryptedPasswordDto(String encryptedSource, String salt) {
+		return EncryptedSourceDto.builder()
+			.encryptedSource(encryptedSource)
+			.salt(salt)
+			.build();
+	}
+}

--- a/src/main/java/personal/hdproject/util/encryption/Sha256Util.java
+++ b/src/main/java/personal/hdproject/util/encryption/Sha256Util.java
@@ -9,17 +9,21 @@ import java.util.stream.IntStream;
 public class Sha256Util {
 	private static final String ENCRYPTION_TYPE = "SHA-256";
 
-	public static String getEncrypt(String source) {
+	public static EncryptedSourceDto getEncryptDto(String source) {
 		String salt = generateSalt();
+		String encryptedSource = getEncryptedSourceWithSalt(source, salt);
 
-		return getEncrypt(source, salt.getBytes());
+		return EncryptedSourceDto.builder()
+			.encryptedSource(encryptedSource)
+			.salt(salt)
+			.build();
 	}
 
-	private static String getEncrypt(String source, byte[] salt) {
+	public static String getEncryptedSourceWithSalt(String source, String salt) {
 		try {
-			byte[] bytes = new byte[source.getBytes().length + salt.length];
 			MessageDigest md = MessageDigest.getInstance(ENCRYPTION_TYPE);
-			byte[] byteData = md.digest(bytes);
+
+			byte[] byteData = md.digest(source.concat(salt).getBytes());
 
 			return IntStream.range(0, byteData.length)
 				.mapToObj(i -> String.format("%02x", byteData[i]))

--- a/src/main/java/personal/hdproject/util/interceptor/WebConfig.java
+++ b/src/main/java/personal/hdproject/util/interceptor/WebConfig.java
@@ -18,7 +18,8 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(memberLoginCheckHandler)
-			.excludePathPatterns("/api/v1/member/sign-in")
+			.excludePathPatterns("/api/v1/auth/sign-in")
+			.excludePathPatterns("/api/v1/auth/refresh-token")
 			.excludePathPatterns("/api/v1/member")
 			.addPathPatterns("/**");
 	}

--- a/src/main/java/personal/hdproject/util/interceptor/handler/MemberLoginCheckHandler.java
+++ b/src/main/java/personal/hdproject/util/interceptor/handler/MemberLoginCheckHandler.java
@@ -17,7 +17,7 @@ import personal.hdproject.util.jwt.JwtAuthTokenProvider;
 public class MemberLoginCheckHandler implements HandlerInterceptor {
 
 	@Value("${jwt.header}")
-	private static String AUTH_HEADER;
+	private String AUTH_HEADER;
 
 	private final JwtAuthTokenProvider jwtAuthTokenProvider;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,12 @@
 spring:
+  profiles:
+    include: product
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/hot_deal
     username: root
     password: 1234
-
----
 
 redis:
   refresh_token:

--- a/src/test/java/personal/hdproject/member/service/MemberProfileServiceTest.java
+++ b/src/test/java/personal/hdproject/member/service/MemberProfileServiceTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import personal.hdproject.member.dao.MemberRepository;
 import personal.hdproject.member.domain.Member;
 import personal.hdproject.member.service.request.CreateMemberServiceRequest;
-import personal.hdproject.util.encryption.Sha256Util;
 import personal.hdproject.util.error.exception.DuplicateEmailException;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -74,14 +73,10 @@ class MemberProfileServiceTest {
 		Long joinedMemberId = memberProfileService.join(createMemberDTO);
 
 		// then
-		String encryptedPassword = Sha256Util.getEncrypt(password);
-
 		Optional<Member> findMemberOptional = memberRepository.findById(joinedMemberId);
 
-		assertThat(password).isNotEqualTo(encryptedPassword);
-
 		findMemberOptional.ifPresentOrElse(
-			findMember -> assertThat(findMember.getPassword()).isEqualTo(encryptedPassword),
+			findMember -> assertThat(findMember.getPassword()).isNotEqualTo(password),
 			() -> fail("Member should be present")
 		);
 	}

--- a/src/test/java/personal/hdproject/member/web/MemberLoginControllerTest.java
+++ b/src/test/java/personal/hdproject/member/web/MemberLoginControllerTest.java
@@ -36,7 +36,7 @@ class MemberLoginControllerTest extends BaseTestConfig {
 
 		// when  // then
 		mockMvc.perform(
-				post("/api/v1/member/sign-in")
+				post("/api/v1/auth/sign-in")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -55,7 +55,7 @@ class MemberLoginControllerTest extends BaseTestConfig {
 
 		// when  // then
 		mockMvc.perform(
-				post("/api/v1/member/sign-in")
+				post("/api/v1/auth/sign-in")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -75,7 +75,7 @@ class MemberLoginControllerTest extends BaseTestConfig {
 
 		// when  // then
 		mockMvc.perform(
-				post("/api/v1/member/sign-in")
+				post("/api/v1/auth/sign-in")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -89,7 +89,7 @@ class MemberLoginControllerTest extends BaseTestConfig {
 	void logout() throws Exception {
 		// given  // when  // then
 		mockMvc.perform(
-				post("/api/v1/member/sign-out")
+				post("/api/v1/auth/sign-out")
 			)
 			.andDo(print())
 			.andExpect(status().isOk());
@@ -106,7 +106,7 @@ class MemberLoginControllerTest extends BaseTestConfig {
 
 		// when  // then
 		mockMvc.perform(
-				post("/api/v1/member/refresh-token")
+				post("/api/v1/auth/refresh-token")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -124,7 +124,7 @@ class MemberLoginControllerTest extends BaseTestConfig {
 
 		// when  // then
 		mockMvc.perform(
-				post("/api/v1/member/refresh-token")
+				post("/api/v1/auth/refresh-token")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -144,7 +144,7 @@ class MemberLoginControllerTest extends BaseTestConfig {
 
 		// when  // then
 		mockMvc.perform(
-				post("/api/v1/member/refresh-token")
+				post("/api/v1/auth/refresh-token")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)


### PR DESCRIPTION
## 🌱 리팩토링 내용

- SHA-256 Class에서 생성하는 암호화된 패스워드의 코드가 잘못되어 있는 것을 확인했습니다.
  - 본래 salt를 활용한 암호화는 password와 salt를 조합하여 회원가입 시 암호화된 비밀번호를 DB에 저장함과 함께 암호화에 필요한 salt도 어딘가 저장해야합니다.
  - SHA-256은 단방향 암호화 알고리즘이기 때문에 비밀번호를 사용해서 로그인 시에는 복호화를 통해 해당 암호가 맞는지 확인해야하는 프로세스가 있습니다.
  - 이 때 미리 저장했던 salt값을 사용하여 로그인 시 받은 비밀번호를 같은 salt로 암호화하고 DB에 저장되어 있는 암호화된 암호와 일치하는지 확인합니다.

=> 이 부분에 대한 로직이 빠져있는 것을 확인했습니다. 기존 코드는 salt를 생성하더라도 salt를 생성하지 않고 단지 암호만을 가지고 암호화하기 때문에 같은 암호로 가입한 유저들에게는 같은 암호가 해싱되어 저장되는 부분을 확인하여 수정했습니다.

----

- 기존에는 Controller DTO에서 SHA-256 알고리즘으로 암호화하여 Service Layer에 전달하였지만, 이 부분은 SHA-256 클래스를 컨트롤러 DTO가 의존하는 것을 막고자 domain(entity)에서 해당 비밀번호를 암호화하는 것으로 변경했습니다.